### PR TITLE
build(docs): bundle AngularJS assets with docs

### DIFF
--- a/docs/config/services/deployments/debug.js
+++ b/docs/config/services/deployments/debug.js
@@ -5,18 +5,18 @@ module.exports = function debugDeployment(getVersion) {
     name: 'debug',
     examples: {
       commonFiles: {
-        scripts: ['../../../angular.js']
+        scripts: ['../../angular.js']
       },
-      dependencyPath: '../../../'
+      dependencyPath: '../../'
     },
     scripts: [
-      '../angular.js',
-      '../angular-resource.js',
-      '../angular-route.js',
-      '../angular-cookies.js',
-      '../angular-sanitize.js',
-      '../angular-touch.js',
-      '../angular-animate.js',
+      'angular.js',
+      'angular-resource.js',
+      'angular-route.js',
+      'angular-cookies.js',
+      'angular-sanitize.js',
+      'angular-touch.js',
+      'angular-animate.js',
       'components/marked-' + getVersion('marked') + '/lib/marked.js',
       'js/angular-bootstrap/dropdown-toggle.js',
       'components/lunr-' + getVersion('lunr') + '/lunr.js',

--- a/docs/config/services/deployments/default.js
+++ b/docs/config/services/deployments/default.js
@@ -5,18 +5,18 @@ module.exports = function defaultDeployment(getVersion) {
     name: 'default',
     examples: {
       commonFiles: {
-        scripts: ['../../../angular.min.js']
+        scripts: ['../../angular.min.js']
       },
-      dependencyPath: '../../../'
+      dependencyPath: '../../'
     },
     scripts: [
-      '../angular.min.js',
-      '../angular-resource.min.js',
-      '../angular-route.min.js',
-      '../angular-cookies.min.js',
-      '../angular-sanitize.min.js',
-      '../angular-touch.min.js',
-      '../angular-animate.min.js',
+      'angular.min.js',
+      'angular-resource.min.js',
+      'angular-route.min.js',
+      'angular-cookies.min.js',
+      'angular-sanitize.min.js',
+      'angular-touch.min.js',
+      'angular-animate.min.js',
       'components/marked-' + getVersion('marked') + '/marked.min.js',
       'js/angular-bootstrap/dropdown-toggle.min.js',
       'components/lunr-' + getVersion('lunr') + '/lunr.min.js',

--- a/docs/config/services/deployments/jquery.js
+++ b/docs/config/services/deployments/jquery.js
@@ -7,20 +7,20 @@ module.exports = function jqueryDeployment(getVersion) {
       commonFiles: {
         scripts: [
           '../../components/jquery-' + getVersion('jquery') + '/jquery.js',
-          '../../../angular.js'
+          '../../angular.js'
         ]
       },
-      dependencyPath: '../../../'
+      dependencyPath: '../../'
     },
     scripts: [
       'components/jquery-' + getVersion('jquery') + '/jquery.js',
-      '../angular.min.js',
-      '../angular-resource.min.js',
-      '../angular-route.min.js',
-      '../angular-cookies.min.js',
-      '../angular-sanitize.min.js',
-      '../angular-touch.min.js',
-      '../angular-animate.min.js',
+      'angular.min.js',
+      'angular-resource.min.js',
+      'angular-route.min.js',
+      'angular-cookies.min.js',
+      'angular-sanitize.min.js',
+      'angular-touch.min.js',
+      'angular-animate.min.js',
       'components/marked-' + getVersion('marked') + '/lib/marked.js',
       'js/angular-bootstrap/dropdown-toggle.min.js',
       'components/lunr-' + getVersion('lunr') + '/lunr.min.js',

--- a/docs/config/services/deployments/test.js
+++ b/docs/config/services/deployments/test.js
@@ -5,19 +5,19 @@ module.exports = function testDeployment(getVersion) {
     name: 'test',
     examples: {
       commonFiles: {
-        scripts: ['../../../angular.js']
+        scripts: ['../../angular.js']
       },
-      dependencyPath: '../../../'
+      dependencyPath: '../../'
     },
     scripts: [
-      '../angular.js',
-      '../angular-resource.js',
-      '../angular-route.js',
-      '../angular-cookies.js',
-      '../angular-mocks.js',
-      '../angular-sanitize.js',
-      '../angular-touch.js',
-      '../angular-animate.js',
+      'angular.js',
+      'angular-resource.js',
+      'angular-route.js',
+      'angular-cookies.js',
+      'angular-mocks.js',
+      'angular-sanitize.js',
+      'angular-touch.js',
+      'angular-animate.js',
       'components/marked-' + getVersion('marked') + '/lib/marked.js',
       'js/angular-bootstrap/dropdown-toggle.js',
       'components/lunr-' + getVersion('lunr') + '/lunr.js',

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "commit": "git-cz",
     "test-i18n": "jasmine-node i18n/spec",
     "test-i18n-ucd": "jasmine-node i18n/ucd/spec",
-    "build": "npx -y esbuild src/Angular.js --bundle --outfile=dist/angular.js",
-    "build:min": "npx -y esbuild src/Angular.js --bundle --minify --outfile=dist/angular.min.js",
+    "build": "node scripts/build-angular.js",
+    "build:min": "node scripts/build-angular.js",
     "karma": "CHROME_BIN=$(node -e \"process.stdout.write(require('puppeteer').executablePath())\") npx -y --package karma@4.4.1 --package karma-jasmine@1.1.2 --package karma-chrome-launcher@3.1.0 karma",
     "test:jqlite": "npm run karma -- start karma-jqlite.conf.js --single-run",
     "test:jquery": "npm run karma -- start karma-jquery.conf.js --single-run",
@@ -26,7 +26,7 @@
     "test:modules": "npm run build && npm run karma -- start karma-modules.conf.js --single-run && npm run karma -- start karma-modules-ngAnimate.conf.js --single-run && npm run karma -- start karma-modules-ngMock.conf.js --single-run",
     "test:unit": "npm run test:jqlite && npm run test:jquery && npm run test:jquery-2.2 && npm run test:jquery-2.1 && npm run test:modules",
     "test": "npm run test:unit",
-    "docs": "node scripts/build-docs.js"
+    "docs": "npm run build && node scripts/build-docs.js"
   },
   "devDependencies": {
     "angular-benchpress": "0.x.x",

--- a/scripts/build-angular.js
+++ b/scripts/build-angular.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const esbuild = require('esbuild');
+const {mergeFilesFor} = require(path.join(__dirname, '..', 'angularFiles.js'));
+
+async function buildAngular(outputFolder) {
+  const rootDir = path.resolve(__dirname, '..');
+  const outDir = outputFolder || path.join(rootDir, 'build');
+  fs.mkdirSync(outDir, {recursive: true});
+
+  const modules = [
+    {name: 'angular', group: 'angularSrc'},
+    {name: 'angular-resource', group: 'angularSrcModuleNgResource'},
+    {name: 'angular-route', group: 'angularSrcModuleNgRoute'},
+    {name: 'angular-cookies', group: 'angularSrcModuleNgCookies'},
+    {name: 'angular-sanitize', group: 'angularSrcModuleNgSanitize'},
+    {name: 'angular-touch', group: 'angularSrcModuleNgTouch'},
+    {name: 'angular-animate', group: 'angularSrcModuleNgAnimate'},
+    {name: 'angular-mocks', files: [
+      'src/ngMock/angular-mocks.js',
+      'src/ngMock/browserTrigger.js'
+    ]}
+  ];
+
+  for (const mod of modules) {
+    const files = mod.files || mergeFilesFor(mod.group);
+    const code = files
+      .map(f => fs.readFileSync(path.join(rootDir, f), 'utf8'))
+      .join('\n');
+    const base = path.join(outDir, mod.name);
+    fs.writeFileSync(`${base}.js`, code);
+    const result = await esbuild.transform(code, {
+      minify: true,
+      sourcemap: true,
+      sourcefile: `${mod.name}.js`
+    });
+    fs.writeFileSync(`${base}.min.js`, result.code);
+    fs.writeFileSync(`${base}.min.js.map`, result.map);
+  }
+}
+
+if (require.main === module) {
+  buildAngular().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+} else {
+  module.exports = buildAngular;
+}

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -28,6 +28,26 @@ function copyDir(src, dest) {
   fs.cpSync(src, dest, {recursive: true});
 }
 
+function copyAngular() {
+  const buildDir = path.join(rootDir, 'build');
+  const modules = [
+    'angular',
+    'angular-resource',
+    'angular-route',
+    'angular-cookies',
+    'angular-sanitize',
+    'angular-touch',
+    'angular-animate',
+    'angular-mocks'
+  ];
+
+  for (const mod of modules) {
+    copyFile(path.join(buildDir, `${mod}.js`), path.join(outputFolder, `${mod}.js`));
+    copyFile(path.join(buildDir, `${mod}.min.js`), path.join(outputFolder, `${mod}.min.js`));
+    copyFile(path.join(buildDir, `${mod}.min.js.map`), path.join(outputFolder, `${mod}.min.js.map`));
+  }
+}
+
 async function buildApp() {
   const files = glob.sync(path.join(docsDir, 'app/src/**/*.js'), {
     ignore: path.join(docsDir, 'app/src/angular.bind.js')
@@ -94,6 +114,7 @@ async function docGen() {
 }
 
 async function main() {
+  copyAngular();
   await docGen();
   await buildApp();
   await assets();


### PR DESCRIPTION
## Summary
- build AngularJS core and modules with a shared script
- copy prebuilt AngularJS assets into published documentation
- run docs generation after common AngularJS build

## Testing
- `npm test` *(fails: Executed 6219 of 6219 (3 FAILED))*
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_b_68ab9bc831e88321ba7bded3ef2bd387