### PR TITLE
build(docs): wrap bundles and run docs tests

### DIFF
--- a/scripts/build-angular.js
+++ b/scripts/build-angular.js
@@ -12,24 +12,32 @@ async function buildAngular(outputFolder) {
   fs.mkdirSync(outDir, {recursive: true});
 
   const modules = [
-    {name: 'angular', group: 'angularSrc'},
-    {name: 'angular-resource', group: 'angularSrcModuleNgResource'},
-    {name: 'angular-route', group: 'angularSrcModuleNgRoute'},
-    {name: 'angular-cookies', group: 'angularSrcModuleNgCookies'},
-    {name: 'angular-sanitize', group: 'angularSrcModuleNgSanitize'},
-    {name: 'angular-touch', group: 'angularSrcModuleNgTouch'},
-    {name: 'angular-animate', group: 'angularSrcModuleNgAnimate'},
-    {name: 'angular-mocks', files: [
-      'src/ngMock/angular-mocks.js',
-      'src/ngMock/browserTrigger.js'
-    ]}
+    {name: 'angular', group: 'angularSrc', prefix: 'src/angular.prefix', suffix: 'src/angular.suffix'},
+    {name: 'angular-resource', group: 'angularSrcModuleNgResource', prefix: 'src/module.prefix', suffix: 'src/module.suffix'},
+    {name: 'angular-route', group: 'angularSrcModuleNgRoute', prefix: 'src/module.prefix', suffix: 'src/module.suffix'},
+    {name: 'angular-cookies', group: 'angularSrcModuleNgCookies', prefix: 'src/module.prefix', suffix: 'src/module.suffix'},
+    {name: 'angular-sanitize', group: 'angularSrcModuleNgSanitize', prefix: 'src/module.prefix', suffix: 'src/module.suffix'},
+    {name: 'angular-touch', group: 'angularSrcModuleNgTouch', prefix: 'src/module.prefix', suffix: 'src/module.suffix'},
+    {name: 'angular-animate', group: 'angularSrcModuleNgAnimate', prefix: 'src/module.prefix', suffix: 'src/module.suffix'},
+    {
+      name: 'angular-mocks',
+      files: [
+        'src/ngMock/angular-mocks.js',
+        'src/ngMock/browserTrigger.js'
+      ],
+      prefix: 'src/module.prefix',
+      suffix: 'src/module.suffix'
+    }
   ];
 
   for (const mod of modules) {
     const files = mod.files || mergeFilesFor(mod.group);
-    const code = files
-      .map(f => fs.readFileSync(path.join(rootDir, f), 'utf8'))
-      .join('\n');
+    const parts = [
+      fs.readFileSync(path.join(rootDir, mod.prefix), 'utf8'),
+      ...files.map(f => fs.readFileSync(path.join(rootDir, f), 'utf8')),
+      fs.readFileSync(path.join(rootDir, mod.suffix), 'utf8')
+    ];
+    const code = parts.join('\n');
     const base = path.join(outDir, mod.name);
     fs.writeFileSync(`${base}.js`, code);
     const result = await esbuild.transform(code, {

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -6,6 +6,7 @@ const path = require('path');
 const glob = require('glob');
 const esbuild = require('esbuild');
 const Dgeni = require('dgeni');
+const {spawnSync} = require('child_process');
 
 const rootDir = path.resolve(__dirname, '..');
 const docsDir = path.join(rootDir, 'docs');
@@ -113,11 +114,23 @@ async function docGen() {
   await dgeni.generate();
 }
 
+function runDocsTests() {
+  const result = spawnSync(
+    'npm',
+    ['run', 'karma', '--', 'start', path.join(rootDir, 'karma-docs.conf.js'), '--single-run'],
+    {stdio: 'inherit'}
+  );
+  if (result.status !== 0) {
+    throw new Error('Docs tests failed');
+  }
+}
+
 async function main() {
   copyAngular();
   await docGen();
   await buildApp();
   await assets();
+  runDocsTests();
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- ensure angular bundles include prefix/suffix wrappers
- run Karma-based docs tests during docs build

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: ChromeHeadless failed to start)*
- `npm run docs` *(fails: ChromeHeadless failed to start)*

------
https://chatgpt.com/codex/tasks/task_b_68ac2deb8c2c8321a9eef91aa505e469